### PR TITLE
feat: add `omit_expired` option to prune expired certs from chain

### DIFF
--- a/cmd/spiffe-helper/config/config.go
+++ b/cmd/spiffe-helper/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	JWTBundleFileMode        int                `hcl:"jwt_bundle_file_mode"`
 	JWTSVIDFileMode          int                `hcl:"jwt_svid_file_mode"`
 	IncludeFederatedDomains  bool               `hcl:"include_federated_domains"`
+	OmitExpired              bool               `hcl:"omit_expired"`
 	RenewSignal              string             `hcl:"renew_signal"`
 	DaemonMode               *bool              `hcl:"daemon_mode"`
 	HealthCheck              health.CheckConfig `hcl:"health_checks"`
@@ -234,6 +235,7 @@ func NewSidecarConfig(config *Config, log logrus.FieldLogger) *sidecar.Config {
 		JWTBundleFileMode:        fs.FileMode(config.JWTBundleFileMode), //nolint:gosec
 		JWTSVIDFileMode:          fs.FileMode(config.JWTSVIDFileMode),   //nolint:gosec
 		IncludeFederatedDomains:  config.IncludeFederatedDomains,
+		OmitExpired:              config.OmitExpired,
 		JWTBundleFilename:        config.JWTBundleFilename,
 		Log:                      log,
 		RenewSignal:              config.RenewSignal,

--- a/cmd/spiffe-helper/config/config_test.go
+++ b/cmd/spiffe-helper/config/config_test.go
@@ -46,6 +46,7 @@ func TestParseConfig(t *testing.T) {
 	assert.Equal(t, expectedJWTAudience, c.JWTSVIDs[0].JWTAudience)
 	assert.Equal(t, expectedJWTExtraAudiences, c.JWTSVIDs[0].JWTExtraAudiences)
 	assert.True(t, c.AddIntermediatesToBundle)
+	assert.True(t, c.OmitExpired)
 	assert.Equal(t, 444, c.CertFileMode)
 	assert.Equal(t, 444, c.KeyFileMode)
 	assert.Equal(t, 444, c.JWTBundleFileMode)
@@ -350,6 +351,7 @@ func TestNewSidecarConfig(t *testing.T) {
 		CertDir:                 "my-cert-dir",
 		SVIDKeyFileName:         "my-key",
 		IncludeFederatedDomains: true,
+		OmitExpired:             true,
 		JWTSVIDs: []JWTConfig{
 			{
 				JWTAudience:     "my-audience",
@@ -366,6 +368,7 @@ func TestNewSidecarConfig(t *testing.T) {
 	assert.Equal(t, config.CertDir, sidecarConfig.CertDir)
 	assert.Equal(t, config.SVIDKeyFileName, sidecarConfig.SVIDKeyFileName)
 	assert.Equal(t, config.IncludeFederatedDomains, sidecarConfig.IncludeFederatedDomains)
+	assert.Equal(t, config.OmitExpired, sidecarConfig.OmitExpired)
 
 	// Ensure JWT Config was populated correctly
 	require.Equal(t, len(config.JWTSVIDs), len(sidecarConfig.JWTSVIDs))

--- a/cmd/spiffe-helper/config/testdata/helper.conf
+++ b/cmd/spiffe-helper/config/testdata/helper.conf
@@ -20,3 +20,4 @@ jwt_svids = [
   }
 ]
 add_intermediates_to_bundle = true
+omit_expired = true

--- a/pkg/sidecar/config.go
+++ b/pkg/sidecar/config.go
@@ -41,6 +41,9 @@ type Config struct {
 	// If true, includes trust domains from federated servers in the CA bundle.
 	IncludeFederatedDomains bool
 
+	// If true, omits expired X509 certs from the bundle.
+	OmitExpired bool
+
 	// An array with the audience and file name to store the JWT SVIDs. File is Base64-encoded string.
 	JWTSVIDs []JWTConfig
 

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -198,7 +198,7 @@ func (s *Sidecar) setupClients(ctx context.Context) error {
 // updateCertificates Updates the certificates stored in disk and signal the Process to restart
 func (s *Sidecar) updateCertificates(svidResponse *workloadapi.X509Context) {
 	s.config.Log.Debug("Updating X.509 certificates")
-	if err := disk.WriteX509Context(svidResponse, s.config.AddIntermediatesToBundle, s.config.IncludeFederatedDomains, s.config.CertDir, s.config.SVIDFileName, s.config.SVIDKeyFileName, s.config.SVIDBundleFileName, s.config.CertFileMode, s.config.KeyFileMode, s.config.Hint); err != nil {
+	if err := disk.WriteX509Context(svidResponse, s.config.AddIntermediatesToBundle, s.config.IncludeFederatedDomains, s.config.OmitExpired, s.config.CertDir, s.config.SVIDFileName, s.config.SVIDKeyFileName, s.config.SVIDBundleFileName, s.config.CertFileMode, s.config.KeyFileMode, s.config.Hint); err != nil {
 		s.config.Log.WithError(err).Error("Unable to dump bundle")
 		s.health.FileWriteStatuses.X509WriteStatus = writeStatusFailed
 		return

--- a/pkg/sidecar/workloadapi.go
+++ b/pkg/sidecar/workloadapi.go
@@ -39,7 +39,7 @@ func (s *Sidecar) fetchAndWriteX509Context(ctx context.Context) error {
 		return err
 	}
 
-	return disk.WriteX509Context(x509Context, s.config.AddIntermediatesToBundle, s.config.IncludeFederatedDomains, s.config.CertDir, s.config.SVIDFileName, s.config.SVIDKeyFileName, s.config.SVIDBundleFileName, s.config.CertFileMode, s.config.KeyFileMode, s.config.Hint)
+	return disk.WriteX509Context(x509Context, s.config.AddIntermediatesToBundle, s.config.IncludeFederatedDomains, s.config.OmitExpired, s.config.CertDir, s.config.SVIDFileName, s.config.SVIDKeyFileName, s.config.SVIDBundleFileName, s.config.CertFileMode, s.config.KeyFileMode, s.config.Hint)
 }
 
 func (s *Sidecar) fetchAndWriteJWTBundle(ctx context.Context) error {

--- a/test/spiffetest/ca.go
+++ b/test/spiffetest/ca.go
@@ -40,6 +40,16 @@ func (ca *CA) CreateCA() *CA {
 	}
 }
 
+func (ca *CA) CreateExpiredCA() *CA {
+	cert, key := CreateExpiredCACertificate(ca.tb, ca.cert, ca.key)
+	return &CA{
+		tb:     ca.tb,
+		parent: ca,
+		cert:   cert,
+		key:    key,
+	}
+}
+
 func (ca *CA) CreateX509SVID(spiffeID string) ([]*x509.Certificate, crypto.Signer) {
 	cert, key := CreateX509SVID(ca.tb, ca.cert, ca.key, spiffeID)
 	return append([]*x509.Certificate{cert}, ca.chain(false)...), key
@@ -53,8 +63,17 @@ func (ca *CA) Roots() []*x509.Certificate {
 	return []*x509.Certificate{root.cert}
 }
 
+func CreateExpiredCACertificate(tb testing.TB, parent *x509.Certificate, parentKey crypto.Signer) (*x509.Certificate, crypto.Signer) {
+	now := time.Now().UTC()
+	return createCACertificateWithOptions(tb, parent, parentKey, now.Add(-1*time.Hour), now)
+}
+
 func CreateCACertificate(tb testing.TB, parent *x509.Certificate, parentKey crypto.Signer) (*x509.Certificate, crypto.Signer) {
-	now := time.Now()
+	now := time.Now().UTC()
+	return createCACertificateWithOptions(tb, parent, parentKey, now, now.Add(time.Hour))
+}
+
+func createCACertificateWithOptions(tb testing.TB, parent *x509.Certificate, parentKey crypto.Signer, notBefore, notAfter time.Time) (*x509.Certificate, crypto.Signer) {
 	serial := NewSerial(tb)
 
 	key := NewEC256Key(tb)
@@ -65,8 +84,8 @@ func CreateCACertificate(tb testing.TB, parent *x509.Certificate, parentKey cryp
 		},
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		NotBefore:             now,
-		NotAfter:              now.Add(time.Hour),
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
 	}
 	if parent == nil {
 		parent = tmpl


### PR DESCRIPTION
Given `omit_expired = true`
When X509 SVID and CA chain is updated
Then any expired certs will be omitted from output

Given `omit_expired = false` or is unset
When X509 SVID and CA chain is updated
Then all certs are written (same as pre-change behavior)